### PR TITLE
Don't serve traffic in Heroku domain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,5 +36,9 @@ group :test do
   gem 'webdrivers'
 end
 
+group :production do
+  gem "rack-host-redirect", "~> 1.3"
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
+    rack-host-redirect (1.3.0)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -263,6 +265,7 @@ DEPENDENCIES
   minitest-stub_any_instance (~> 1.0)
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
+  rack-host-redirect (~> 1.3)
   rails (~> 6.0.6)
   rubocop (~> 0.82.0)
   rubocop-rails (~> 2.5)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,4 +95,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.middleware.use(Rack::HostRedirect, "webauthn-2fa.herokuapp.com" => URI(ENV["WEBAUTHN_ORIGIN"]).host)
 end


### PR DESCRIPTION
Use [`rack-host-redirect`](https://github.com/gbuesing/rack-host-redirect) gem to redirect traffic away from Heroku domain (https://webauthn-2fa.herokuapp.com) to the main site (https://webauthn-2fa.cedarcode.com) 

This is needed because registering keys in the heroku domain won't work given that it is not WebAuthn expected origin - so a `WebAuthn::OriginVerificationError` will be raised.