### PR TITLE
Don't report ActionController::RoutingError errors to Rollbar

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -33,6 +33,7 @@ Rollbar.configure do |config|
   #
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+  config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
 
   # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
   # is not installed)


### PR DESCRIPTION
Bots trying to find vulnerabilities and getting a 404 are using all our Rollbar quota