### PR TITLE
Use rubocop plugins: for extensions that support it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require: rubocop-rails
+plugins: rubocop-rails
 
 inherit_mode:
   merge:


### PR DESCRIPTION
We were getting this warning

```
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in ~/workspace/webauthn-2fa-rails-demo/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```