### PR TITLE
Install `libssl-dev` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libyaml-dev pkg-config && \
+    apt-get install --no-install-recommends -y build-essential git libssl-dev libyaml-dev pkg-config && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems


### PR DESCRIPTION
The deployment is currently failing due to a missing package required to install the `openssl` gem. Specifically, the `libssl-dev` package is no longer included in the latest patch versions of the official `Ruby` Docker images (3.4.2, 3.3.7, 3.2.8), see [this commit](https://github.com/docker-library/ruby/commit/193c69e863a4c2bf86f6e323cb294fe1b8e1e845#diff-8d7a21b017921bb88eaf71656b7b5767203db16e8126fc1e5ad2a9ba0bc542f5L237).

We didn't encounter this issue previously because our deployments used an earlier `Ruby` image that still included `libssl-dev` by default. Now that we've upgraded to `Ruby 3.4.2`, we need to install `libssl-dev`.

We probably need to install this package in the rest of the apps that uses `webauthn`.