### PR TITLE
Disable `rollbarjs` in test and development

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,11 +4,6 @@ Rollbar.configure do |config|
 
   config.access_token = ENV['ROLLBAR_POST_SERVER_ITEM_ACCESS_TOKEN']
 
-  # Here we'll disable in 'test' and 'development':
-  if Rails.env.test? || Rails.env.development?
-    config.enabled = false
-  end
-
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`
   # method to fetch this property. To customize:
@@ -72,6 +67,7 @@ Rollbar.configure do |config|
 
   # Enable Rollbar.js
   config.js_enabled = true
+
   config.js_options = {
     accessToken: ENV['ROLLBAR_POST_CLIENT_ITEM_ACCESS_TOKEN'],
     captureUncaught: true,
@@ -79,4 +75,11 @@ Rollbar.configure do |config|
       environment: ENV['ROLLBAR_ENV'].presence || Rails.env
     }
   }
+
+  # Here we'll disable in 'test' and 'development':
+  if Rails.env.test? || Rails.env.development?
+    config.enabled = false
+    config.js_enabled = false
+  end
+
 end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,6 +4,11 @@ Rollbar.configure do |config|
 
   config.access_token = ENV['ROLLBAR_POST_SERVER_ITEM_ACCESS_TOKEN']
 
+  # Here we'll disable in 'test' and 'development':
+  unless Rails.env.production?
+    config.enabled = false
+  end
+
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`
   # method to fetch this property. To customize:
@@ -65,21 +70,16 @@ Rollbar.configure do |config|
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
   config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
 
-  # Enable Rollbar.js
-  config.js_enabled = true
+  if Rails.env.production?
+    # Enable Rollbar.js
+    config.js_enabled = true
 
-  config.js_options = {
-    accessToken: ENV['ROLLBAR_POST_CLIENT_ITEM_ACCESS_TOKEN'],
-    captureUncaught: true,
-    payload: {
-      environment: ENV['ROLLBAR_ENV'].presence || Rails.env
+    config.js_options = {
+      accessToken: ENV['ROLLBAR_POST_CLIENT_ITEM_ACCESS_TOKEN'],
+      captureUncaught: true,
+      payload: {
+        environment: ENV['ROLLBAR_ENV'].presence || Rails.env
+      }
     }
-  }
-
-  # Here we'll disable in 'test' and 'development':
-  if Rails.env.test? || Rails.env.development?
-    config.enabled = false
-    config.js_enabled = false
   end
-
 end


### PR DESCRIPTION
#### Summary

We're getting warnings from the rollbar gem when it adds the js middleware.

```ruby
/ruby/3.4.0/gems/rollbar-3.6.2/lib/rollbar/middleware/js.rb:126:
warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

This is because they need to add the `# frozen_string_literal: true` magic comment.

This PR disables rollbar js middleware for `test` and `development` environment.