### PR TITLE
Use `assert_text` to fix flaky system tests

### DIFF
--- a/test/system/add_credential_test.rb
+++ b/test/system/add_credential_test.rb
@@ -13,6 +13,8 @@ class AddCredentialTest < ApplicationSystemTestCase
 
     visit root_url
 
+    assert_text "Sign in"
+
     fill_in "Username", with: "me"
     fill_in "Password", with: "password"
 
@@ -21,6 +23,8 @@ class AddCredentialTest < ApplicationSystemTestCase
     assert_text "Please enable Two-Factor Authentication in the button below:"
 
     visit new_webauthn_credential_path
+
+    assert_text "Add a security key"
 
     fake_credentials = fake_client.create(challenge: challenge)
     stub_create(fake_credentials)

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -9,6 +9,8 @@ class SignInTest < ApplicationSystemTestCase
   test "signing in" do
     visit root_url
 
+    assert_text "Sign in"
+
     fill_in "Username", with: "me"
     fill_in "Password", with: "password"
 
@@ -20,6 +22,8 @@ class SignInTest < ApplicationSystemTestCase
   test "signing in fails with wrong username" do
     visit root_url
 
+    assert_text "Sign in"
+
     fill_in "Username", with: "other"
     fill_in "Password", with: "password"
 
@@ -30,6 +34,8 @@ class SignInTest < ApplicationSystemTestCase
 
   test "signing in fails with wrong password" do
     visit root_url
+
+    assert_text "Sign in"
 
     fill_in "Username", with: "me"
     fill_in "Password", with: "wrong-password"
@@ -50,6 +56,8 @@ class SignInTest < ApplicationSystemTestCase
                                 webauthn_credential: webauthn_credential)
 
     visit new_session_path
+
+    assert_text "Sign in"
 
     fill_in "Username", with: "other"
     fill_in "Password", with: "password"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -4,6 +4,8 @@ class UsersTest < ApplicationSystemTestCase
   test "signing up" do
     visit new_user_url
 
+    assert_text "Create your account"
+
     fill_in "Username", with: "me"
     fill_in "Password", with: "password"
     fill_in "Password confirmation", with: "password"
@@ -17,6 +19,8 @@ class UsersTest < ApplicationSystemTestCase
 
   test "signing up fails with wrong confirmation" do
     visit new_user_url
+
+    assert_text "Create your account"
 
     fill_in "Username", with: "me"
     fill_in "Password", with: "password"


### PR DESCRIPTION
#### Summary
Previously, we weren't asserting any content after navigating to a new page, which may be the reason that lead to flaky system tests.

This PR adds `assert_text` calls after each navigation.